### PR TITLE
Include current folder as lib so perl recognizes Utils dir

### DIFF
--- a/convert_to_1p4/convert_to_1p4.pl
+++ b/convert_to_1p4/convert_to_1p4.pl
@@ -3,6 +3,7 @@
 #
 # Copyright 2014 Mike Cappella (mike@cappella.us)
 
+use lib ".";
 use v5.14;
 use utf8;
 use strict;


### PR DESCRIPTION
The change in this PR helped me to solve this error:

```
c:\Users\mkokh\Desktop\convert_to_1p4>perl convert_to_1p4.pl 
Can't locate Utils/PIF.pm in @INC (you may need to install the Utils::PIF module) (@INC contains: C:/MyPerl/perl/site/lib C:/MyPerl/perl/vendor/lib C:/MyPerl/perl/lib .)
```